### PR TITLE
Added shortcut to bypass confirmation modal

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Destiny 2 Season Pass Wayback Machine",
   "description": "A simple extension which allows you to view and claim earned but unclaimed season pass rewards from past seasons in Destiny 2.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "icons": {
     "128": "assets/icon.png"
   },

--- a/src/app/components/content/Item.tsx
+++ b/src/app/components/content/Item.tsx
@@ -77,7 +77,8 @@ export const SeasonPassItem = React.memo(
             ) {
               return;
             }
-            const isBypassConfirmation = e.ctrlKey;
+
+            const isBypassConfirmation = e.ctrlKey || e.metaKey;
 
             if (isBypassConfirmation) {
               claimItem();

--- a/src/app/components/content/Item.tsx
+++ b/src/app/components/content/Item.tsx
@@ -68,7 +68,7 @@ export const SeasonPassItem = React.memo(
               "opacity-50": isClaimed
             }
           )}
-          onClick={() => {
+          onClick={(e) => {
             console.log(item);
             if (
               isClaimed ||
@@ -77,8 +77,13 @@ export const SeasonPassItem = React.memo(
             ) {
               return;
             }
+            const isBypassConfirmation = e.ctrlKey;
 
-            setIsConfirmModalOpen(true);
+            if (isBypassConfirmation) {
+              claimItem();
+            } else {
+              setIsConfirmModalOpen(true);
+            }
           }}
         >
           <img

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,33 +11,33 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: path.resolve(__dirname, "manifest.json"),
+          src: "manifest.json",
           dest: "."
         },
         {
-          src: path.resolve(__dirname, "src/popup.html"),
+          src: "src/popup.html",
           dest: "."
         },
         {
-          src: path.resolve(__dirname, "icon.png"),
-          dest: "./assets"
+          src: "icon.png",
+          dest: "assets"
         }
       ]
     })
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src")
+      "@": path.resolve("src")
     }
   },
   build: {
-    outDir: path.resolve(__dirname, "build"),
+    outDir: "build",
     minify: false,
     target: ["chrome111", "firefox110"],
     rollupOptions: {
       input: {
-        content: path.resolve(__dirname, "src/content.tsx"),
-        styles: path.resolve(__dirname, "src/styles.css")
+        content: "src/content.tsx",
+        styles: "src/styles.css"
       },
       output: {
         entryFileNames: "[name].js",


### PR DESCRIPTION
changed path names in viteStaticCopy to fix build errors and added a ctrl+click option to instantly claim item